### PR TITLE
Revert "Rewrite makefiles into a production ready build system"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
+/build
 
 HelloWorldPlus
-*.o
 *.exe

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,21 @@
-.POSIX:
+CC = gcc
+CFLAGS = -g -Wall
 
-include config.mk
+UNAME := $(shell uname)
 
-all: options HelloWorldPlus
+ifeq ($(UNAME), Linux)
+TARGET = -lncurses
+else
+TARGET = 
+endif
 
-options:
-	@echo HelloWorldPlus build options:
-	@echo "CFLAGS  = $(MYCFLAGS)"
-	@echo "LDFLAGS = $(MYLDFLAGS)"
-	@echo "CC      = $(CC)"
+default: helloworld
 
-HelloWorldPlus: src/main.o
-	$(CC) $(MYLDFLAGS) $< -o $@
+helloworld: build/main.o
+	$(CC) $(CFLAGS) -o HelloWorldPlus build/main.o $(TARGET)
 
-src/main.o: src/main.c
-	$(CC) $(MYCFLAGS) -c $< -o $@
+build/main.o: build src/main.c
+	$(CC) $(CFLAGS) -c src/main.c -o build/main.o
 
-clean:
-	rm -f src/main.o HelloWorldPlus
-
-.PHONY: all
+build:
+	mkdir $@

--- a/config.mk
+++ b/config.mk
@@ -1,8 +1,0 @@
-
-
-# libs
-AVAIL_NCURSES=`ldconfig -p | grep ncurses > /dev/null 2>&1 && printf "0" || printf "1"`
-LIBS=`ldconfig -p | grep ncurses > /dev/null 2>&1 && printf "%s" "-lncurses" || printf ""`
-
-MYCFLAGS=-Wall $(CFLAGS)
-MYLDFLAGS=$(LIBS) $(LDFLAGS)


### PR DESCRIPTION
Reverts Trey2k/HelloWorldPlus#1
Couple issues, first of all a lot of systems do not have a default for CC so we should probably set a default to GCC (the better C compiler), second issue is windows does not have commands like grep so the build will fail on windows.

